### PR TITLE
Bumped spellcheck action to latest version (0.19.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Basic dependabot.yml file
+# REF: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Look for `.github/workflows` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/spell.yaml
+++ b/.github/workflows/spell.yaml
@@ -12,5 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: rojopolis/spellcheck-github-actions@0.13.0
+      - uses: rojopolis/spellcheck-github-actions@0.19.0
         name: Spellcheck

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,0 +1,2 @@
+Parham
+kish

--- a/english/first-condition.txt
+++ b/english/first-condition.txt
@@ -3,9 +3,9 @@
 3. If you are sad, I will be sad.
 4. If I get angry, I will run.
 5. If he gets fired, I will be poor.
-6. If I don't eat breakfast before exam, I wil ruin exam.
+6. If I don't eat breakfast before exam, I will ruin exam.
 7. If he uses C programming language, his program will be fast.
 8. If he comes, I will not come.
 9. If you win the award, I will be very happy.
-10. If I finish my homeworks, we will go to the party.
+10. If I finish my homework, we will go to the party.
 11. If I eat to much, I will be fat.

--- a/english/present-questions.txt
+++ b/english/present-questions.txt
@@ -7,7 +7,7 @@
 4. who works over there ?
 5. who goes there everyday ?
 6. what contains 9 planets in space ?
-7. who kils a cop these days ?
+7. who kills a cop these days ?
 8. who always drinks coffee for breakfast like me ?
 9. who swims every day ?
 10. who plays chess every night ?
@@ -34,7 +34,7 @@
 5. who is doing your homework ?
 6. who is reading the book tomorrow ?
 7. who is washing my car right now ?
-8. whos car is involving in today's crash ?
+8. whose car is involving in today's crash ?
 9. who is going to beach tomorrow ?
 10. who is climbing the mountain tomorrow ?
 

--- a/spellcheck.yaml
+++ b/spellcheck.yaml
@@ -4,5 +4,8 @@ matrix:
     aspell:
       lang: en
       d: en_US
+    dictionary:
+      wordlists:
+      - .wordlist.txt
     sources:
       - english/**.txt


### PR DESCRIPTION
Hello,

I have just [released 0.19.0 of the GitHub Spellcheck Action](https://dev.to/jonasbn/releases-0190-of-spellcheck-github-action-a-security-release-599k) and I noticed that older versions of the Docker image had been pulled from DockerHub recently. 

I was able to locate your configuration via [SourceGraph](https://sourcegraph.com/github.com/1995parham/Learning/-/blob/.github/workflows/spell.yaml), so I am providing you with a PR proposing an update to a more contemporary version.

It should be backwards compatible even though a lot has happened, but if you experience any issue with the PR please let me know and I will comply.

Take care and stay safe,

jonasbn